### PR TITLE
norm vadim resonance

### DIFF
--- a/plugins/VadimFilter/VadimFilter.sc
+++ b/plugins/VadimFilter/VadimFilter.sc
@@ -1,6 +1,6 @@
 VadimFilter : UGen {
-	*ar { |input, freq=500, resonance=1.0, type=0|
-		^this.multiNew('audio', input, freq, resonance, type);
+	*ar { |input, freq=500, resonance=0.25, type=0|
+		^this.multiNew('audio', input, freq, resonance*4.0, type);
 	}
 
 	checkInputs {

--- a/plugins/VadimFilter/VadimFilter.schelp
+++ b/plugins/VadimFilter/VadimFilter.schelp
@@ -20,7 +20,7 @@ ARGUMENT::freq
 Cutoff / center frequency (depending on type) in herz. May be modulated at control rate.
 
 ARGUMENT::resonance
-Resonance. Range: 0.0 to 4.0.
+Resonance. Range: 0.0 to 1.0.
 
 ARGUMENT::type
 An integer that sets the filter up as one of the following types:
@@ -43,7 +43,7 @@ Ndef(\va, { |freq=150|
 		input: in,
 		type: 1,
 		freq: LFNoise2.kr(10).exprange(20.0,20000.0),
-		resonance: LFNoise2.kr(1).range(0.0,4.0)
+		resonance: LFNoise2.kr(1).range(0.0,1.0)
 	)!2
 }).play;
 )


### PR DESCRIPTION
This is just a cozy cozy res val normalization PR. Close/Reject it at will :)~
First I just did a `in0( Resonance * 4.0f )` in line 19 and 39 (**VadimFilter.cpp**). 
Though a mult of `4.0` on the `.sc` side gets the job done. Hacky. But normalized res values are nice.