### PR TITLE
use daisysp v0.0.2 in CMakeLists.txt; Fix #39

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,7 +676,7 @@ if(USE_DAISYSP_LIB)
 	CPMAddPackage(
 		NAME daisysp
 		GITHUB_REPOSITORY "electro-smith/DaisySP"
-		GIT_TAG master
+		GIT_TAG v0.0.2
 		)
 
 	include_directories("include/daisysp")


### PR DESCRIPTION
Changes the version of daisysp from currently v1 to v0.0.2. This will fix problem #39 
no further changes

With the changes of daisysp to version v1.0 its divided into a lgpl branch. See #39 for more information.
Just adding 
```
target_compile_definitions("${plugin_name}_scsynth PUBLIC "USE_DAISYSP_LGPL")
```
doesnt work, because daisysp doesnt load daisysp_lgpl automaticly