### PR TITLE
add M_E definition so DaisySP compiles with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,6 +672,10 @@ if(USE_DAISYSP_LIB)
 	# Print message to let user know these are being built
 	message(STATUS "Adding DaisySP plugins")
 
+  if (MSVC)
+    add_compile_definitions(M_E 2.7182818284590452354)
+  endif()
+
 	# Add DaisySP library
 	CPMAddPackage(
 		NAME daisysp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,7 +680,7 @@ if(USE_DAISYSP_LIB)
 	CPMAddPackage(
 		NAME daisysp
 		GITHUB_REPOSITORY "electro-smith/DaisySP"
-		GIT_TAG v0.0.2
+		GIT_TAG master
 		)
 
 	include_directories("include/daisysp")


### PR DESCRIPTION
Compilation was broken with MSVC since its math.h doesn't include math constants like GNU does, and the DaisySP ADSR need M_E defined. I just added the definition in CMakeLists.txt, but let me know if you think there's a better way. Thanks!